### PR TITLE
Fixes test due to catch + rethrow. Fixes deposit function to correctly add funds to target account.

### DIFF
--- a/src/activities.ts
+++ b/src/activities.ts
@@ -15,9 +15,10 @@ export async function withdraw(details: PaymentDetails): Promise<string> {
     );
     return result;
   } catch (error) {
-    throw new Error('Unexpected error occurred');
+    console.warn('withdrawal error:', error);
+    throw error;
   }
-};
+}
 // @@@SNIPEND
 
 // @@@SNIPSTART money-transfer-project-template-ts-deposit-activity
@@ -34,13 +35,14 @@ export async function deposit(details: PaymentDetails): Promise<string> {
   // );
   try {
     const result = await bank2.deposit(
-      details.sourceAccount,
+      details.targetAccount,
       details.amount,
       details.referenceId
     );
     return result;
   } catch (error) {
-    throw new Error('Unexpected error occurred');
+    console.warn('deposit error:', error);
+    throw error;
   }
 }
 // @@@SNIPEND
@@ -59,7 +61,8 @@ export async function refund(details: PaymentDetails): Promise<string> {
     );
     return result;
   } catch (error) {
-    throw new Error('Unexpected error occurred');
+    console.warn('refund error:', error);
+    throw error;
   }
 }
 // @@@SNIPEND


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 


<!--- For ALL Contributors 👇 -->

## What was changed
Fixes unit tests failing due to a catch + rethrow exception, which bypasses `nonRetryableErrorTypes`.
Also fixed the implementation of `deposit` to add funds to the target account instead of source account.

## Why?
Found this while following the Getting Started examples and trying to run the tests, which would fail locally.

## Checklist
<!--- add/delete as needed --->

1. How was this tested:
`npm run test`

1. Any docs updates needed?
The docs website might need to be updated
