### PR TITLE
fix: refund error handling

### DIFF
--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -37,14 +37,14 @@ export async function moneyTransfer(details: PaymentDetails): Promise<string> {
     let refundResult;
     try {
       refundResult = await refund(details);
-      throw ApplicationFailure.create({
-        message: `Failed to deposit money into account ${details.targetAccount}. Money returned to ${details.sourceAccount}. Cause: ${depositErr}.`,
-      });
     } catch (refundErr) {
       throw ApplicationFailure.create({
         message: `Failed to deposit money into account ${details.targetAccount}. Money could not be returned to ${details.sourceAccount}. Cause: ${refundErr}.`,
       });
     }
+    throw ApplicationFailure.create({
+      message: `Failed to deposit money into account ${details.targetAccount}. Money returned to ${details.sourceAccount}. Cause: ${depositErr}.`,
+    });
   }
   return `Transfer complete (transaction IDs: ${withdrawResult}, ${depositResult})`;
 }


### PR DESCRIPTION
## What was changed
The catch clause for errors in the refund activity was moved.

## Why?
When the refund activity executes successfully, it throws an error to indicate that the workflow has failed but that the funds were refunded.  However, this error is caught by another catch clause and subsequently rethrown with additional error information.  This second catch clause is intended to catch errors in the refund activity, but it is in the wrong place.

The result is that if the refund succeeds, the workflow result has the confusing message that the refund both failed and succeeded.

## Checklist
How was this tested:
Follow the instructions in the temporarl documentation on how to simulate a failed deposit. 
1. replace the BankService deposit call with depositThatFails in activities.ts
2. modify the maximumAttempts to 3 in workflows.ts
3. npm run client
The resulting error message is that the deposit failed but the refund was successfully executed.
