### PR TITLE
Changed Location of Error

### DIFF
--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -28,7 +28,7 @@ export async function moneyTransfer(details: PaymentDetails): Promise<string> {
     throw new ApplicationFailure(`Withdrawal failed. Error: ${withdrawErr}`);
   }
 
-  //Execute the deposit Activity
+  // Execute the deposit Activity
   let depositResult: string;
   try {
     depositResult = await deposit(details);


### PR DESCRIPTION
## What was changed
Changed the location of a thrown error. Before, even if `refund(details)` was successful, an error would be thrown within the try block, which would cause the `Money could not be returned` error to be thrown. I believe the `catch(refundErr)` block should only catch errors due to `refund(details)`.

### Tested
Ran it in a local environment

### Doc updates?
I'm not sure if the [online course](https://temporal.talentlms.com/unit/view/id:5931) that uses this code will need to be separately updated.
