### PR TITLE
moved error and fixed comment

### DIFF
--- a/src/workflows.ts
+++ b/src/workflows.ts
@@ -28,7 +28,7 @@ export async function moneyTransfer(details: PaymentDetails): Promise<string> {
     throw new ApplicationFailure(`Withdrawal failed. Error: ${withdrawErr}`);
   }
 
-  //Execute the deposit Activity
+  // Execute the deposit Activity
   let depositResult: string;
   try {
     depositResult = await deposit(details);
@@ -37,14 +37,14 @@ export async function moneyTransfer(details: PaymentDetails): Promise<string> {
     let refundResult;
     try {
       refundResult = await refund(details);
-      throw ApplicationFailure.create({
-        message: `Failed to deposit money into account ${details.targetAccount}. Money returned to ${details.sourceAccount}. Cause: ${depositErr}.`,
-      });
     } catch (refundErr) {
       throw ApplicationFailure.create({
         message: `Failed to deposit money into account ${details.targetAccount}. Money could not be returned to ${details.sourceAccount}. Cause: ${refundErr}.`,
       });
     }
+    throw ApplicationFailure.create({
+      message: `Failed to deposit money into account ${details.targetAccount}. Money returned to ${details.sourceAccount}. Cause: ${depositErr}.`,
+    });
   }
   return `Transfer complete (transaction IDs: ${withdrawResult}, ${depositResult})`;
 }


### PR DESCRIPTION
### What was changed
Changed the location of a thrown error. Before, even if `refund(details)` was successful, an error would be thrown within the try block, which would cause the `Money could not be returned` error to be thrown. I believe the `catch(refundErr)` block should only catch errors due to `refund(details)`.

### Tested
Ran it in a local environment

### Doc updates?
I'm not sure if the [online course](https://temporal.talentlms.com/unit/view/id:5931) that uses this code will need to be separately updated.
